### PR TITLE
Avoid concurrent calls to external methods

### DIFF
--- a/SoftU2F/SoftU2FDriver.cpp
+++ b/SoftU2F/SoftU2FDriver.cpp
@@ -27,7 +27,9 @@ bool SoftU2FDriver::start(IOService *provider) {
 }
 
 void SoftU2FDriver::free() {
+  IOLog("%s[%p]::%s()\n", getName(), this, __FUNCTION__);
   OSSafeReleaseNULL(_workLoop);
+  super::free();
 }
 
 IOWorkLoop* SoftU2FDriver::getWorkLoop() const {

--- a/SoftU2F/SoftU2FDriver.cpp
+++ b/SoftU2F/SoftU2FDriver.cpp
@@ -16,8 +16,20 @@ bool SoftU2FDriver::start(IOService *provider) {
 
   if (!super::start(provider))
     return false;
+  
+  _workLoop = IOWorkLoop::workLoop();
+  if (!_workLoop)
+    return false;
 
   registerService();
 
   return true;
+}
+
+void SoftU2FDriver::free() {
+  OSSafeReleaseNULL(_workLoop);
+}
+
+IOWorkLoop* SoftU2FDriver::getWorkLoop() const {
+  return _workLoop;
 }

--- a/SoftU2F/SoftU2FDriver.cpp
+++ b/SoftU2F/SoftU2FDriver.cpp
@@ -16,7 +16,7 @@ bool SoftU2FDriver::start(IOService *provider) {
 
   if (!super::start(provider))
     return false;
-  
+
   _workLoop = IOWorkLoop::workLoop();
   if (!_workLoop)
     return false;

--- a/SoftU2F/SoftU2FDriver.hpp
+++ b/SoftU2F/SoftU2FDriver.hpp
@@ -9,12 +9,17 @@
 #define SoftU2FDriver_hpp
 
 #include <IOKit/IOService.h>
+#include <IOKit/IOWorkLoop.h>
 
 class SoftU2FDriver : public IOService {
   OSDeclareDefaultStructors(SoftU2FDriver)
+  
+  IOWorkLoop *_workLoop;
 
 public :
   virtual bool start(IOService *provider) override;
+  void free() override;
+  IOWorkLoop* getWorkLoop() const override;
 };
 
 #endif /* SoftU2F_hpp */

--- a/SoftU2F/SoftU2FDriver.hpp
+++ b/SoftU2F/SoftU2FDriver.hpp
@@ -13,7 +13,7 @@
 
 class SoftU2FDriver : public IOService {
   OSDeclareDefaultStructors(SoftU2FDriver)
-  
+
   IOWorkLoop *_workLoop;
 
 public :

--- a/SoftU2F/SoftU2FDriver.hpp
+++ b/SoftU2F/SoftU2FDriver.hpp
@@ -14,7 +14,7 @@
 class SoftU2FDriver : public IOService {
   OSDeclareDefaultStructors(SoftU2FDriver)
 
-  IOWorkLoop *_workLoop;
+  IOWorkLoop *_workLoop = nullptr;
 
 public :
   virtual bool start(IOService *provider) override;

--- a/SoftU2F/SoftU2FUserClient.hpp
+++ b/SoftU2F/SoftU2FUserClient.hpp
@@ -13,12 +13,13 @@
 #include "UserKernelShared.h"
 #include <IOKit/IOService.h>
 #include <IOKit/IOUserClient.h>
+#include <IOKit/IOCommandGate.h>
 
 class SoftU2FUserClient : public IOUserClient {
   OSDeclareDefaultStructors(SoftU2FUserClient)
 
-protected:
-  OSAsyncReference64 *fNotifyRef = nullptr;
+private:
+  OSAsyncReference64 *_notifyRef = nullptr;
   static const IOExternalMethodDispatch sMethods[kNumberOfMethods];
 
 public:

--- a/SoftU2F/SoftU2FUserClient.hpp
+++ b/SoftU2F/SoftU2FUserClient.hpp
@@ -19,13 +19,26 @@ class SoftU2FUserClient : public IOUserClient {
   OSDeclareDefaultStructors(SoftU2FUserClient)
 
 private:
-  OSAsyncReference64 *_notifyRef = nullptr;
   static const IOExternalMethodDispatch sMethods[kNumberOfMethods];
+  OSAsyncReference64 *_notifyRef;
+  IOCommandGate *_commandGate;
+
+  typedef struct {
+    uint32_t                    selector;
+    IOExternalMethodArguments * arguments;
+    IOExternalMethodDispatch *  dispatch;
+    OSObject *                  target;
+    void *                      reference;
+  } ExternalMethodGatedArguments;
+
+  IOReturn externalMethodGated(ExternalMethodGatedArguments * arguments);
+  virtual void frameReceivedGated(IOMemoryDescriptor *report);
 
 public:
   virtual void free() override;
 
   virtual bool start(IOService *provider) override;
+  virtual void stop(IOService *provider) override;
 
   virtual IOReturn clientClose(void) override;
 

--- a/SoftU2F/SoftU2FUserClient.hpp
+++ b/SoftU2F/SoftU2FUserClient.hpp
@@ -20,8 +20,8 @@ class SoftU2FUserClient : public IOUserClient {
 
 private:
   static const IOExternalMethodDispatch sMethods[kNumberOfMethods];
-  OSAsyncReference64 *_notifyRef;
-  IOCommandGate *_commandGate;
+  OSAsyncReference64 *_notifyRef = nullptr;
+  IOCommandGate *_commandGate = nullptr;
 
   typedef struct {
     uint32_t                    selector;


### PR DESCRIPTION
This PR moves user client interactions onto a work loop to prevent races. Fixes #10.